### PR TITLE
Implement delayed second photo capture

### DIFF
--- a/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/MediaFragment.kt
+++ b/SampleCode-V5/android-sdk-v5-sample/src/main/java/dji/sampleV5/aircraft/pages/MediaFragment.kt
@@ -200,6 +200,17 @@ class MediaFragment : DJIFragment() {
             mediaVM.takePhoto(object : CommonCallbacks.CompletionCallback {
                 override fun onSuccess() {
                     ToastUtils.showToast("take photo success")
+                    mainHandler.postDelayed({
+                        mediaVM.takePhoto(object : CommonCallbacks.CompletionCallback {
+                            override fun onSuccess() {
+                                ToastUtils.showToast("take photo success")
+                            }
+
+                            override fun onFailure(error: IDJIError) {
+                                ToastUtils.showToast("take photo failed $error")
+                            }
+                        })
+                    }, 1000)
                 }
 
                 override fun onFailure(error: IDJIError) {


### PR DESCRIPTION
## Summary
- modify `MediaFragment` to trigger a second photo shot one second after the first

## Testing
- `./gradlew assembleDebug` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_684d8745c62083328fbfe7cfe211d67e